### PR TITLE
Update README: Package control instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The package author tries his best to keep up to date with the ongoing developmen
 
 ##### Package Control
 
-As this package is and will never be added to the official [packagecontrol.io](https://packagecontrol.io/) for official reasons, you need to add the following settings to your _Package_control.sublime-settings_ if you want Package Control to keep this package up to date for you.
+As this package is and will never be added to the official [packagecontrol.io](https://packagecontrol.io/) for official reasons, you need to add the following settings to your _User/Package Control.sublime-settings_ if you want Package Control to keep this package up to date for you.
 
 ```json
 "repositories":
@@ -30,6 +30,8 @@ As this package is and will never be added to the official [packagecontrol.io](h
     "sublime-commands": "Default"
 }
 ```
+
+Open command palette, select "Package Control: Install Package", search for "Default" and install it.
 
 ##### Manual Setup
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ As this package is and will never be added to the official [packagecontrol.io](h
 }
 ```
 
-Open command palette, select "Package Control: Install Package", search for "Default" and install it.
+Save the settings file.
+Open command palette, select _Package Control: Install Package_, search for _Default_ and install it.
 
 ##### Manual Setup
 


### PR DESCRIPTION
Oh yeah, baby, hacktoberfest README update time!

---

So anyway, Package Control didn't automagically install this package after I modified and saved its settings. For not-so-much experienced it may not be obvious that these instructions are incomplete.