### PR TITLE
Fix misspelled word of command palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sublime Commands
 
-Sublime Text's command pallet misses most of the internal commands exposed by the main menu.
+Sublime Text's command palette misses most of the internal commands exposed by the main menu.
 
 Packages like [Missing Commands](https://github.com/fjl/Sublime-Missing-Palette-Commands) therefore provide all commands not located in Sublime Text's _Default_ package.
 

--- a/line_endings.py
+++ b/line_endings.py
@@ -40,7 +40,7 @@ class SetLineEndings(sublime_plugin.TextCommand):
     """A replacement command for the builtin `set_line_ending`.
 
     This class provides an input handler to list the available line endings
-    in the command pallet using an `ListInputHanlder` rather then listing all
+    in the command palette using an `ListInputHanlder` rather then listing all
     the values as separate commands.
     """
 


### PR DESCRIPTION
I think it should be **Command Palette**, which is also the word official used. Remember to also change the description in the About section!